### PR TITLE
:bug: Fix payload undefined value

### DIFF
--- a/src/companies/companies.service.ts
+++ b/src/companies/companies.service.ts
@@ -68,7 +68,7 @@ export class CompaniesService {
   private async findCompany(loginId: string) {
     const company = await this.companyRepo.findOne({
       where: { loginId },
-      select: ['password'],
+      select: ['id', 'password'],
     });
 
     return company;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -61,7 +61,7 @@ export class UsersService {
   private async findUser(loginId: string) {
     const user = await this.userRepo.findOne({
       where: { loginId },
-      select: ['password'],
+      select: ['id', 'password'],
     });
 
     return user;


### PR DESCRIPTION
1. 페이로드에 id값을 `sub: company.id` `sub: user.id` 이런식으로 넣음
2. `id` select를 안해줘서 undefined로 들어감
3. jwt strategy에서 `payload.sub`으로 id 불러와 repo에서 찾는데, undefined로 들어감
4. where 무효화되어서 무조건 맨 처음값이 리턴

어차피 login_id도 유니크값이고 페이로드 포함되어 있어서 3번에서 그걸로 찾아도 되는데, 그냥 덜 만지는 방식으로 수정하였음!